### PR TITLE
Add periods to plugin descriptions for consistency.

### DIFF
--- a/plugins/movetoarchive.koplugin/_meta.lua
+++ b/plugins/movetoarchive.koplugin/_meta.lua
@@ -2,5 +2,5 @@ local _ = require("gettext")
 return {
     name = "movetoarchive",
     fullname = _("Move to archive"),
-    description = _([[Moves/copies current book to archive folder]]),
+    description = _([[Moves/copies current book to archive folder.]]),
 }

--- a/plugins/terminal.koplugin/_meta.lua
+++ b/plugins/terminal.koplugin/_meta.lua
@@ -2,5 +2,5 @@ local _ = require("gettext")
 return {
     name = "terminal",
     fullname = _("Terminal emulator"),
-    description = _([[KOReader's terminal emulator]]),
+    description = _([[KOReader's terminal emulator.]]),
 }


### PR DESCRIPTION
These two plugins' description did not have periods, yet all others did.
Side note: I couldn't find the metadata for the deprecation warning for "Export Notes". Maybe it got removed in older commit? I'm too lazy to check though.